### PR TITLE
Test under Linux and OSX, with gcc and clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,20 @@
+sudo: false
+
 language: c
 
+os:
+    - linux
+    - osx
+
+compiler:
+    - clang
+    - gcc
+
 before_script:
-    - ./autogen.sh
+    - export PKG_CONFIG_PATH=/tmp/lib/pkgconfig
+    - git clone https://github.com/jedisct1/libsodium.git --branch=stable
+    - cd libsodium && ./autogen.sh && ./configure --enable-minimal --disable-dependency-tracking --prefix=/tmp && make install && cd -
+    - ./autogen.sh    
 
 script:
-    - ./configure && make
+    - ./configure --disable-dependency-tracking && make distcheck

--- a/configure.ac
+++ b/configure.ac
@@ -7,15 +7,7 @@ AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 AM_SILENT_RULES([yes])
 AC_CONFIG_SRCDIR([common.h])
 AC_PROG_CC_C99
-AC_CHECK_HEADERS([arpa/inet.h netdb.h stdint.h stdlib.h sys/ioctl.h sys/socket.h unistd.h])
-AC_C_INLINE
-AC_C_RESTRICT
-AC_TYPE_SIZE_T
-AC_TYPE_SSIZE_T
-AC_TYPE_UINT8_T
-AC_TYPE_INT64_T
-AC_FUNC_MALLOC
-AC_CHECK_FUNCS([socket strtol])
+AC_USE_SYSTEM_EXTENSIONS
 AC_SEARCH_LIBS(clock_gettime, [rt],
   [AC_DEFINE(HAVE_CLOCK_GETTIME,[1],[define if you have clock_gettime()])])
 PKG_CHECK_MODULES([libsodium], [libsodium >= 1.0.4],

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_PREREQ([2.68])
+AC_PREREQ([2.65])
 AC_INIT([glorytun], [0.0.1],
         [https://github.com/angt/glorytun/issues],
         [glorytun],

--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,10 @@ AC_TYPE_SSIZE_T
 AC_TYPE_UINT8_T
 AC_TYPE_INT64_T
 AC_FUNC_MALLOC
-AC_CHECK_FUNCS([clock_gettime socket strtol])
-PKG_CHECK_MODULES([libsodium], [libsodium >= 1.0.4])
+AC_CHECK_FUNCS([socket strtol])
+AC_SEARCH_LIBS(clock_gettime, [rt],
+  [AC_DEFINE(HAVE_CLOCK_GETTIME,[1],[define if you have clock_gettime()])])
+PKG_CHECK_MODULES([libsodium], [libsodium >= 1.0.4],
+  [CFLAGS="$CFLAGS $libsodium_CFLAGS"], [echo "not found"])
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,8 @@ AC_INIT([glorytun], [0.0.1],
         [https://github.com/angt/glorytun/issues],
         [glorytun],
         [https://github.com/angt/glorytun])
-AM_INIT_AUTOMAKE([-Wall -Werror foreign])
+AM_INIT_AUTOMAKE([1.9 -Wall -Werror foreign tar-ustar])
+AM_DEP_TRACK
 AM_SILENT_RULES([yes])
 AC_CONFIG_SRCDIR([common.h])
 AC_PROG_CC_C99

--- a/configure.ac
+++ b/configure.ac
@@ -9,8 +9,10 @@ AM_SILENT_RULES([yes])
 AC_CONFIG_SRCDIR([common.h])
 AC_PROG_CC_C99
 AC_USE_SYSTEM_EXTENSIONS
-AC_SEARCH_LIBS(clock_gettime, [rt],
+AC_SEARCH_LIBS([clock_gettime], [rt],
   [AC_DEFINE(HAVE_CLOCK_GETTIME,[1],[define if you have clock_gettime()])])
+AC_SEARCH_LIBS([getaddrinfo], [resolv nsl])
+AC_SEARCH_LIBS([socket], [socket])
 PKG_CHECK_MODULES([libsodium], [libsodium >= 1.0.4],
   [CFLAGS="$CFLAGS $libsodium_CFLAGS"], [echo "not found"])
 AC_CONFIG_FILES([Makefile])

--- a/glorytun.c
+++ b/glorytun.c
@@ -1,6 +1,7 @@
 #include "common-static.h"
 
 #include <stdio.h>
+#include <stdint.h>
 #include <signal.h>
 #include <poll.h>
 #include <time.h>

--- a/glorytun.c
+++ b/glorytun.c
@@ -567,7 +567,7 @@ static void option_usage (struct option *opts, char *name)
         size_t inc = str_len(opts[k].name)+(isflag?0:4)+4;
 
         if (len+inc>60) {
-            printf("\n%*s", slen, "");
+            printf("\n%*s", (int) slen, "");
             len = 0;
         }
         printf(" [%s%s]", opts[k].name, isflag?"":" ARG");

--- a/glorytun.c
+++ b/glorytun.c
@@ -1,5 +1,6 @@
 #include "common-static.h"
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <signal.h>
@@ -216,12 +217,12 @@ static socklen_t sk_get_info (int fd, struct tcp_info *ti)
 static void print_tcp_info (struct tcp_info *ti)
 {
     fprintf(stderr, "tcpinfo"
-            " rto:%llu"        " ato:%llu"             " snd_mss:%llu"
-            " rcv_mss:%llu"    " unacked:%llu"         " sacked:%llu"
-            " lost:%llu"       " retrans:%llu"         " fackets:%llu"
-            " pmtu:%llu"       " rcv_ssthresh:%llu"    " rtt:%llu"
-            " rttvar:%llu"     " snd_ssthresh:%llu"    " snd_cwnd:%llu"
-            " advmss:%llu"     " reordering:%llu"      "\n",
+            " rto:%" PRIu32     " ato:%" PRIu32          " snd_mss:%" PRIu32
+            " rcv_mss:%" PRIu32 " unacked:%" PRIu32      " sacked:%" PRIu32
+            " lost:%" PRIu32    " retrans:%" PRIu32      " fackets:%" PRIu32
+            " pmtu:%" PRIu32    " rcv_ssthresh:%" PRIu32 " rtt:%" PRIu32
+            " rttvar:%" PRIu32  " snd_ssthresh:%" PRIu32 " snd_cwnd:%" PRIu32
+            " advmss:%" PRIu32  " reordering:%" PRIu32   "\n",
             ti->tcpi_rto,      ti->tcpi_ato,           ti->tcpi_snd_mss,
             ti->tcpi_rcv_mss,  ti->tcpi_unacked,       ti->tcpi_sacked,
             ti->tcpi_lost,     ti->tcpi_retrans,       ti->tcpi_fackets,


### PR DESCRIPTION
Test under Linux and OSX, with gcc and clang

Properly export CPPFLAGS/LDFLAGS from pkg-config

Test packaging with `distcheck`.