### PR TITLE
Include <sys/socket.h> for AF_INET/AF_INET6 definitions

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -13,6 +13,7 @@
 #include <signal.h>
 #include <poll.h>
 #include <fcntl.h>
+#include <sys/socket.h>
 #include <sys/time.h>
 #include <sys/stat.h>
 


### PR DESCRIPTION
Required on OpenBSD.