### PR TITLE
Cope with branches that don't have tags

### DIFF
--- a/version.sh
+++ b/version.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-[ -z "${VERSION}" ] && VERSION=`git describe --tags --always 2>/dev/null` \
+[ -z "${VERSION}" ] && VERSION=`git describe --tags --always 2>/dev/null | \
+                                fgrep .` \
                     && VERSION=${VERSION#v}
 
 [ -z "${VERSION}" ] && VERSION=`cat VERSION 2>/dev/null`


### PR DESCRIPTION
`version.sh` used to return only the hash of the last commit, causing `VERSION_MAJOR` to possibly contain non-numeric junk.