### PR TITLE
Flush stdout after a line

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -9,6 +9,7 @@ int gt_print (const char *fmt, ...)
     va_start(ap, fmt);
     int ret = vfprintf(stdout, fmt, ap);
     va_end(ap);
+    fflush(stdout);
 
     if (ret<0)
         return 0;


### PR DESCRIPTION
Retrieving the name of the interface chosen by glorytun is required when more than one tunnel are running on the same host.

Unfortunately, getting this name is currently quite tricky. It's printed to `stdout`, but when `stdout` is not a tty, it's block-buffered, so `| fgrep 'tun name:'` is unlikely to yield anything.

This just makes `gt_print()` line-buffered in order to work around this.