### PR TITLE
include <net/if.h>

### DIFF
--- a/src/tun.c
+++ b/src/tun.c
@@ -11,6 +11,8 @@
 #include <sys/socket.h>
 #include <sys/uio.h>
 
+#include <net/if.h>
+
 #ifdef __linux__
 #include <linux/if.h>
 #include <linux/if_tun.h>


### PR DESCRIPTION
Required on BSD. Doesn't break anything elsewhere.