### PR TITLE
per-path peer endpoints & glorytun path status

### DIFF
--- a/src/ctl.h
+++ b/src/ctl.h
@@ -22,6 +22,7 @@ struct ctl_msg {
     union {
         struct {
             struct sockaddr_storage addr;
+            struct sockaddr_storage peer;
             enum mud_state state;
             unsigned long rate_tx;
             unsigned long rate_rx;
@@ -34,8 +35,8 @@ struct ctl_msg {
             long pid;
             size_t mtu;
             int chacha;
+            int master;
             struct sockaddr_storage bind;
-            struct sockaddr_storage peer;
         } status;
         struct mud_conf conf;
         struct mud_path path_status;

--- a/src/show.c
+++ b/src/show.c
@@ -60,52 +60,29 @@ gt_show_status(int fd)
     gt_toaddr(bindstr, sizeof(bindstr),
               (struct sockaddr *)&res.status.bind);
 
-    int server = gt_toaddr(peerstr, sizeof(peerstr),
-                           (struct sockaddr *)&res.status.peer);
+    const char *modestr = NULL;
+    modestr = res.status.master ? "master" : "slave";
 
     int term = isatty(1);
 
-    if (server) {
-        printf(term ? "server %s:\n"
-                      "  pid:    %li\n"
-                      "  bind:   %s port %"PRIu16"\n"
-                      "  mtu:    %zu\n"
-                      "  cipher: %s\n"
-                    : "server %s"
-                      " %li"
-                      " %s %"PRIu16
-                      " %zu"
-                      " %s"
-                      "\n",
-               res.status.tun_name,
-               res.status.pid,
-               bindstr[0] ? bindstr : "-",
-               gt_get_port((struct sockaddr *)&res.status.bind),
-               res.status.mtu,
-               GT_CIPHER(res.status.chacha));
-    } else {
-        printf(term ? "client %s:\n"
-                      "  pid:    %li\n"
-                      "  bind:   %s port %"PRIu16"\n"
-                      "  peer:   %s port %"PRIu16"\n"
-                      "  mtu:    %zu\n"
-                      "  cipher: %s\n"
-                    : "client %s"
-                      " %li"
-                      " %s %"PRIu16
-                      " %s %"PRIu16
-                      " %zu"
-                      " %s"
-                      "\n",
-               res.status.tun_name,
-               res.status.pid,
-               bindstr[0] ? bindstr : "-",
-               gt_get_port((struct sockaddr *)&res.status.bind),
-               peerstr[0] ? peerstr : "-",
-               gt_get_port((struct sockaddr *)&res.status.peer),
-               res.status.mtu,
-               GT_CIPHER(res.status.chacha));
-    }
+    printf(term ? "%s %s:\n"
+                  "  pid:    %li\n"
+                  "  bind:   %s port %"PRIu16"\n"
+                  "  mtu:    %zu\n"
+                  "  cipher: %s\n"
+                : "%s %s"
+                  " %li"
+                  " %s %"PRIu16
+                  " %zu"
+                  " %s"
+                  "\n",
+           modestr,
+           res.status.tun_name,
+           res.status.pid,
+           bindstr[0] ? bindstr : "-",
+           gt_get_port((struct sockaddr *)&res.status.bind),
+           res.status.mtu,
+           GT_CIPHER(res.status.chacha));
 
     return 0;
 }

--- a/systemd/glorytun-run
+++ b/systemd/glorytun-run
@@ -2,5 +2,4 @@
 
 exec glorytun bind "$@" \
 	$BIND $BIND_PORT \
-	${DEV:+dev "$DEV"} \
-	${HOST:+to "$HOST" "$PORT"}
+	${DEV:+dev "$DEV"}

--- a/systemd/glorytun-setup
+++ b/systemd/glorytun-setup
@@ -39,14 +39,22 @@ fi
 # install files
 mkdir -p "$DIR"
 
-cat > "$DIR/env" <<EOF
+if [ "$HOST" ]
+then
+	cat > "$DIR/env" <<EOF
 DEV=gt${HOST:+c}-$NAME
-HOST=$HOST
-PORT=$PORT
+BIND=$BIND
+BIND_PORT=$BIND_PORT
+OPTIONS="master"
+EOF
+else
+	cat > "$DIR/env" <<EOF
+DEV=gt${HOST:+c}-$NAME
 BIND=$BIND
 BIND_PORT=$BIND_PORT
 OPTIONS=
 EOF
+fi
 
 ( umask 077; echo "$KEY" > "$DIR/key" )
 
@@ -61,7 +69,7 @@ SRC=$(ip route get "$HOST" | awk '/src/{getline;print $0}' RS=' ')
 ip rule add from "$SRC" table main pref "$((PREF-1))" || true
 
 # limit to 100Mbit by default
-glorytun path up "$SRC" dev "$DEV" rate rx 12500000 tx 12500000
+glorytun path up "$SRC" peer "$HOST" "$PORT" dev "$DEV" rate rx 12500000 tx 12500000
 
 # forward everything else to the tunnel
 ip rule add from all table "$TABLE" pref "$PREF" || true


### PR DESCRIPTION
This pull request does 2 things:
* it allows setting per-path endpoints (https://github.com/angt/mud/pull/6) - fixes https://github.com/angt/glorytun/issues/44
* adds back the detailed glorytun path command under `glorytun path status`

The first change obviously requires some breaking CLI changes:
* the user no longer creates a client tunnel with `glorytun bind <ipaddr> <port> to <peeraddr> <peerport>`
* instead the peer endpoint is specified when creating a path - `glorytun path up <ipaddr> peer <peeraddr> <peerport>`
* when creating a master tunnel the `master` options has to be used - `glorytun bind <ipaddr> <port> master`
* master is the side that controls the path, slave learns the available paths from master - i.e. `client` is now `master`, `server` is now `slave`